### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:0.12
+MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
+
+RUN useradd node
+RUN mkdir -p /home/node /usr/src/app /var/control-repo
+RUN chown -R node:node /home/node
+RUN npm install -g grunt-cli
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+RUN npm install -g .
+
+VOLUME /var/control-repo
+WORKDIR /var/control-repo
+
+USER node
+ENTRYPOINT ["/usr/src/app/script/entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ RUN mkdir -p /home/node /usr/src/app /var/control-repo
 RUN chown -R node:node /home/node
 RUN npm install -g grunt-cli
 
-COPY . /usr/src/app
-WORKDIR /usr/src/app
-RUN npm install -g .
+COPY script/entrypoint /usr/src/app/script/entrypoint
 
 VOLUME /var/control-repo
 WORKDIR /var/control-repo

--- a/script/entrypoint
+++ b/script/entrypoint
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Primary entrypoint for the Docker container.
+
+set -euo pipefail
+
+npm install
+grunt "$@"


### PR DESCRIPTION
This adds a Docker container that runs `npm install` and `grunt` within a mounted volume. This'll let me use it within the deconst client without needing to worry about conflicting grunt or node versions.
