### PR TITLE
Use Alpine as a base image for the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:0.12
+FROM alpine:3.2
 MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
 
-RUN useradd node
+RUN apk add --update nodejs && rm -rf /var/cache/apk/*
+
+RUN adduser -D node
 RUN mkdir -p /home/node /usr/src/app /var/control-repo
 RUN chown -R node:node /home/node
 RUN npm install -g grunt-cli

--- a/script/entrypoint
+++ b/script/entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Primary entrypoint for the Docker container.
 


### PR DESCRIPTION
Because:

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
after               latest              a2133420b612        7 seconds ago       24.05 MB
before              latest              5b5a51297f69        10 minutes ago      644.9 MB
```
