### PR TITLE
Run an npm script instead of grunt.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apk add --update nodejs git && rm -rf /var/cache/apk/*
 RUN adduser -D node
 RUN mkdir -p /home/node /usr/src/app /var/control-repo
 RUN chown -R node:node /home/node
-RUN npm install -g grunt-cli
 
 COPY script/entrypoint /usr/src/app/script/entrypoint
 

--- a/script/entrypoint
+++ b/script/entrypoint
@@ -5,4 +5,4 @@
 set -euo pipefail
 
 npm install
-grunt "$@"
+npm run deconst-control-build


### PR DESCRIPTION
Preparing for the strider-deconst-control builder to run `npm` instead of `grunt`, as described in deconst/strider-deconst-control#4.
