### PR TITLE
Put npm's temp and cache dirs somewhere writable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ COPY script/entrypoint /usr/src/app/script/entrypoint
 
 VOLUME /var/control-repo
 WORKDIR /var/control-repo
+ENV NPM_CONFIG_CACHE /var/control-repo/.cache/
+ENV TMPDIR /var/control-repo/.tmp/
 
 USER node
 ENTRYPOINT ["/usr/src/app/script/entrypoint"]


### PR DESCRIPTION
The Deconst client runs the asset preparer's container with a read-only filesystem. If npm has anything to install, it tries to use `/tmp` and `${HOME}/.npm` as working directories for caching and such. Putting this in the mounted volume prevents npm from blowing up or just not installing things.

This will _further_ muck things up if you have more than one preparer running against the same control repository directory... but that caused lots of problems anyway.
