### PR TITLE
Optionally accept a CONTROL_ROOT.

### DIFF
--- a/script/entrypoint
+++ b/script/entrypoint
@@ -4,5 +4,7 @@
 
 set -euo pipefail
 
+[ -n "${CONTROL_ROOT:-}" ] && cd ${CONTROL_ROOT}
+
 npm install
 npm run deconst-control-build


### PR DESCRIPTION
Accept a `CONTROL_ROOT` environment variable to prepare control repositories from paths other than the cwd, notably `--volumes-from` mounted paths.

In service of deconst/strider-deconst-content#3.
