### PR TITLE
Minor tweaks to avoid deprecations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
 RUN apk add --update nodejs ruby git && rm -rf /var/cache/apk/*
 
 RUN adduser -D -g "" -u 1000 node
-RUN mkdir -p /home/node /usr/src/app /var/control-repo
-RUN chown -R node:node /home/node
+RUN mkdir -p /home/node /usr/src/app /var/control-repo /var/npmdata/
+RUN chown -R node:node /home/node /var/npmdata/
 
 RUN gem install --no-document sass
 
@@ -13,8 +13,8 @@ COPY script/entrypoint /usr/src/app/script/entrypoint
 
 VOLUME /var/control-repo
 WORKDIR /var/control-repo
-ENV NPM_CONFIG_CACHE /var/control-repo/.cache/
-ENV TMPDIR /var/control-repo/.tmp/
+ENV NPM_CONFIG_CACHE /var/npmdata/.cache/
+ENV TMPDIR /var/npmdata/.tmp/
 
 USER node
 ENTRYPOINT ["/usr/src/app/script/entrypoint"]

--- a/tasks/deconst_assets.js
+++ b/tasks/deconst_assets.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
             request.post({
                 url: ConfigService.get('url') + '/assets?named=true',
                 headers: {
-                    'Authorization': 'deconst apikey="' + ConfigService.get('key') + '"'
+                    'Authorization': 'deconst ' + ConfigService.get('key')
                 },
                 formData: formData
             }, function (error, response, body) {


### PR DESCRIPTION
The `apikey=""` bit is no longer necessary in the `Authorization` header.
